### PR TITLE
Fix #3 Created new endpoint for getting profiles by hobby

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,5 +9,6 @@
 <body>
     <p>Endpoint for all profiles is <a href="./profiles">/profiles</a></p>
     <p>Endpoint to get a specific profile by roll number is /profiles/[roll number] (NOT case sensitive) for example <a href="./profiles/lcs2020000">/profiles/lcs2020000</a></p>
+    <p>Endpoint to get profiles by hobbies is /profiles?hobby=[hobbyName] for example <a href="./profiles?hobby=writing">/profiles?hobby=writing</a></p>
 </body>
 </html>

--- a/routes/profiles.js
+++ b/routes/profiles.js
@@ -8,8 +8,15 @@ router.get('/:roll_number', (req, res) => { // returns profile with the requeste
     else res.sendStatus(404)
 })
 
-router.get('/', (req, res) => { // returns profiles of all the participants
-    res.send(data)
+router.get('/', (req, res) => {
+    if (req.query.hobby){
+    let hobby = req.query.hobby;
+    const result = data.filter(val => val.hobbies.includes(hobby));
+    if (result.length != 0) res.send(result)
+    else res.sendStatus(404)
+    } else {
+        res.send(data)
+    }
 })
 
 module.exports = router


### PR DESCRIPTION
### Created new endpoint for getting profiles by hobby
#3 
Created a new endpoint which returns data for ALL (not just 1) the participants who have the requested hobby in their array of hobbies. The URL will be something like http://localhost:3000/profiles?hobby=reading.

A link to the new endpoint in the homepage public/index.html has been added too
<img width="730" alt="1" src="https://user-images.githubusercontent.com/96474794/157887516-7fae4c31-0f88-42f1-b760-14d36e602ae8.png">
<img width="611" alt="2" src="https://user-images.githubusercontent.com/96474794/157887534-bea2adc9-c57c-4368-8dec-ee9583c30567.png">
<img width="692" alt="3" src="https://user-images.githubusercontent.com/96474794/157887546-d41c025c-fb59-426d-9988-1e2968d81687.png">
