### PR TITLE
Fix #9 Created new endpoint for getting roll numbers of all participants

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,5 +9,6 @@
 <body>
     <p>Endpoint for all profiles is <a href="./profiles">/profiles</a></p>
     <p>Endpoint to get a specific profile by roll number is /profiles/[roll number] (NOT case sensitive) for example <a href="./profiles/lcs2020000">/profiles/lcs2020000</a></p>
+    <p>Endpoint for all roll-numbers is <a href="./profiles/roll-numbers">/profiles/roll-numbers</a></p>
 </body>
 </html>

--- a/routes/profiles.js
+++ b/routes/profiles.js
@@ -3,7 +3,13 @@ const express = require("express")
 const router = express.Router()
 
 router.get('/:roll_number', (req, res) => { // returns profile with the requested roll number
-    const result = data.find(profile => profile.roll_number.toLowerCase() === req.params.roll_number.toLowerCase())
+    let rollNumber = req.params.roll_number;
+    let result;
+    if (rollNumber == "roll-numbers"){
+        result = data.map(profile => profile.roll_number.toLowerCase())
+    } else {
+        result = data.find(profile => profile.roll_number.toLowerCase() === rollNumber.toLowerCase())
+    }
     if(result) res.send(result)
     else res.sendStatus(404)
 })


### PR DESCRIPTION
### New endpoint for getting roll numbers of all participants #9 
Created a new endpoint which returns an array with the roll numbers of ALL the participants in profiles.json. The URL is http://localhost:3000/profiles/roll-numbers.

A link to the new endpoint in the homepage public/index.html has been added

<img width="722" alt="13" src="https://user-images.githubusercontent.com/96474794/157894717-90c3486e-5483-44ec-8e0f-7dbeb018f1b3.png">
<img width="463" alt="12" src="https://user-images.githubusercontent.com/96474794/157894724-f719ff56-fc6e-4247-861f-ae7640c8bf90.png">
<img width="693" alt="11" src="https://user-images.githubusercontent.com/96474794/157894745-625011f3-d13c-40a4-96b3-261b0eb1ff26.png">

